### PR TITLE
Fix: Correct Buy Box - Current column data issues

### DIFF
--- a/Keepa_Deals.py
+++ b/Keepa_Deals.py
@@ -73,7 +73,7 @@ def fetch_product(asin, days=365, offers=100, rating=1, history=1):
         return {'stats': {'current': [-1] * 30}, 'asin': asin}
     logging.debug(f"Fetching ASIN {asin} for {days} days, history={history}, offers={offers}, no_cache={args.no_cache}")
     print(f"Fetching ASIN {asin}...")
-    url = f"https://api.keepa.com/product?key={api_key}&domain=1&asin={asin}&stats={days}&offers={offers}&rating={rating}&history={history}&stock=1"
+    url = f"https://api.keepa.com/product?key={api_key}&domain=1&asin={asin}&stats={days}&offers={offers}&rating={rating}&history={history}&stock=1&buybox=1"
     headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/90.0.4430.212'}
     try:
         response = requests.get(url, headers=headers, timeout=60)

--- a/stable_products.py
+++ b/stable_products.py
@@ -377,9 +377,10 @@ def sales_rank_drops_last_365_days(product):
 # Buy Box - Current starts
 def buy_box_current(product):
     asin = product.get('asin', 'unknown')
+    logging.debug(f"Buy Box - Current - ASIN {asin} - Raw current array: {product.get('stats', {}).get('current', [-1] * 20)}")
     stats = product.get('stats', {})
     current = stats.get('current', [-1] * 20)
-    value = current[0] if len(current) > 10 else -1
+    value = current[0] if len(current) > 0 else -1
     logging.debug(f"Buy Box - Current - raw value={value}, current array={current}, stats_keys={list(stats.keys())} for ASIN {asin}")
     if value <= 0 or value == -1:
         logging.warning(f"No valid Buy Box - Current (value={value}, current_length={len(current)}) for ASIN {asin}")


### PR DESCRIPTION
The "Buy Box - Current" column in Keepa_Deals_Export.csv was showing missing or incorrect values. This commit addresses the issue by:

1. Modifying the `buy_box_current` function in `stable_products.py`:
    - Changed the condition for accessing `stats.current[0]` from `len(current) > 10` to `len(current) > 0`. This ensures that the Buy Box price is retrieved if `current[0]` contains it, even if the `current` array is shorter than 11 elements.
    - Added debug logging for the raw `current` array to aid future troubleshooting.

2. Updating the API call in `Keepa_Deals.py`:
    - Added the `&buybox=1` parameter to the `fetch_product` API request URL. This explicitly requests Buy Box information from the Keepa API, which should improve the reliability and accuracy of the data returned in `stats.current[0]`.

These changes aim to ensure that the Buy Box price is more reliably and accurately fetched and processed.